### PR TITLE
$? instead of $() for getting exit code

### DIFF
--- a/scripts/sap-app-pas-install-single-hosts.sh
+++ b/scripts/sap-app-pas-install-single-hosts.sh
@@ -812,8 +812,8 @@ fi
 echo
 echo "Start set_s3_download @ $(date)"
 echo
-_SET_S3=$(set_s3_download)
-
+#_SET_S3=$(set_s3_download)
+set_s3_download; _SET_S3=$?; echo "EXIT CODE _SET_S3: $_SET_S3"
 if [ "$_SET_S3" == 0 ]
 then
      echo "Successfully downloaded the s/w"


### PR DESCRIPTION
_SET_S3=$(set_s3_download) false failure for SLES12SP3 + NFS even if completed successfully
line was changed to:
set_s3_download; _SET_S3=$?; echo "EXIT CODE _SET_S3: $_SET_S3"