### PR TITLE
EFS Mount Options and Typo on S3 variables

### DIFF
--- a/scripts/sap-app-aas-install.sh
+++ b/scripts/sap-app-aas-install.sh
@@ -363,7 +363,7 @@ set_sapmnt() {
         #construct the EFS DNS name
         EFS_MP=""$EFS_MT".efs."$REGION".amazonaws.com:/ "
 
-        echo ""$EFS_MP"  "$SAPMNT"  nfs rw,soft,bg,timeo=3,intr 0 0"  >> $FSTAB_FILE
+        echo ""$EFS_MP"  "$SAPMNT"  nfs nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport 0 0"  >> $FSTAB_FILE
         
         #try to mount /sapmnt 3 times 
         mount /sapmnt > /dev/null

--- a/scripts/sap-app-ascs-install.sh
+++ b/scripts/sap-app-ascs-install.sh
@@ -350,7 +350,7 @@ set_sapmnt() {
         #construct the EFS DNS name
         EFS_MP=""$EFS_MT".efs."$REGION".amazonaws.com:/ "
 
-        echo ""$EFS_MP"  "$SAPMNT"  nfs rw,soft,bg,timeo=3,intr 0 0"  >> $FSTAB_FILE
+        echo ""$EFS_MP"  "$SAPMNT"  nfs nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport  0 0"  >> $FSTAB_FILE
         
         #try to mount /sapmnt 3 times 
         mount /sapmnt > /dev/null
@@ -515,12 +515,12 @@ set_s3_download() {
           
 
           #download the media from the S3 bucket provided
-          _S3_DL=$(aws s3 sync "s3://${S3_BUCKET}/${S3_BUCKET_KP}" "$SW_TARGET" 2>&1 >/dev/null | grep "download failed")
+          S3_DL=$(aws s3 sync "s3://${S3_BUCKET}/${S3_BUCKET_KP}" "$SW_TARGET" 2>&1 >/dev/null | grep "download failed")
 
           if [ -n "$S3_DL" ]
           then
                #download failed for some reason, try to download again
-               _S3_DL2=$(aws s3 sync "s3://${S3_BUCKET}/${S3_BUCKET_KP}" "$SW_TARGET" 2>&1 >/dev/null | grep "download failed")
+               S3_DL2=$(aws s3 sync "s3://${S3_BUCKET}/${S3_BUCKET_KP}" "$SW_TARGET" 2>&1 >/dev/null | grep "download failed")
         
               if [ -n "$S3_DL2" ]
               then

--- a/scripts/sap-app-pas-install-single-hosts.sh
+++ b/scripts/sap-app-pas-install-single-hosts.sh
@@ -384,7 +384,7 @@ set_EFS() {
         #construct the EFS DNS name
         EFS_MP=""$EFS_MT".efs."$REGION".amazonaws.com:/ "
 
-        echo ""$EFS_MP"  "$SAPMNT"  nfs rw,soft,bg,timeo=3,intr 0 0"  >> $FSTAB_FILE
+        echo ""$EFS_MP"  "$SAPMNT"  nfs nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport 0 0"  >> $FSTAB_FILE
         
         #try to mount /sapmnt 3 times 
         mount /sapmnt > /dev/null
@@ -431,12 +431,12 @@ set_s3_download() {
 #download the s/w
           
           #download the media from the S3 bucket provided
-          _S3_DL=$(aws s3 sync "s3://${S3_BUCKET}/${S3_BUCKET_KP}" "$SW_TARGET" 2>&1 >/dev/null | grep "download failed")
+          S3_DL=$(aws s3 sync "s3://${S3_BUCKET}/${S3_BUCKET_KP}" "$SW_TARGET" 2>&1 >/dev/null | grep "download failed")
 
           if [ -n "$S3_DL" ]
           then
                #download failed for some reason, try to download again
-               _S3_DL2=$(aws s3 sync "s3://${S3_BUCKET}/${S3_BUCKET_KP}" "$SW_TARGET" 2>&1 >/dev/null | grep "download failed")
+               S3_DL2=$(aws s3 sync "s3://${S3_BUCKET}/${S3_BUCKET_KP}" "$SW_TARGET" 2>&1 >/dev/null | grep "download failed")
         
               if [ -n "$S3_DL2" ]
               then

--- a/scripts/sap-app-pas-install.sh
+++ b/scripts/sap-app-pas-install.sh
@@ -373,7 +373,7 @@ set_sapmnt() {
         #construct the EFS DNS name
         EFS_MP=""$EFS_MT".efs."$REGION".amazonaws.com:/ "
 
-        echo ""$EFS_MP"  "$SAPMNT"  nfs rw,soft,bg,timeo=3,intr 0 0"  >> $FSTAB_FILE
+        echo ""$EFS_MP"  "$SAPMNT"  nfs nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport  0 0"  >> $FSTAB_FILE
         
         #try to mount /sapmnt 3 times 
         mount /sapmnt > /dev/null


### PR DESCRIPTION
Hello,

Submitting this PR to fix all NFS mount options using EFS to match the recommended mount options from our documentation [1].

I also fixed a typo on a few variables from set_s3_download() functions to remove an "_" character.

References:
[1] https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html